### PR TITLE
Cloud Development Kit Configuration for Lambda Deployment of Titiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ ENV/
 .mypy_cache/
 
 cdk.out/
+
+# lambda deployment package
+lambda/package.zip

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A lightweight Cloud Optimized GeoTIFF tile server.
 ### ø AWS ECS (Fargate) + ALB (Application Load Balancer)
 The stack is deployed by the [aws cdk](https://aws.amazon.com/cdk/) utility. It will handle tasks such as generating a docker image and packaging handlers automatically.
 
-1. Instal cdk and set up CDK in your AWS account - Only need once per account
+1. Install cdk and set up CDK in your AWS account - Only need once per account
 ```bash
 $ npm install cdk -g
 

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -16,24 +16,28 @@ handler = Mangum(app, enable_lifespan=False)
 
 ```bash
 $ git clone https://github.com/developmentseed/titiler.git
-$ cd titiler/lambda
 ```
 
-2. Build Docker image and save package
+2. Deploy -- Using serverless
+
+
+2.1. Build Docker image and save package 
 
 ```bash
-docker build --tag lambda:latest .
-docker run --name lambda -itd lambda:latest /bin/bash
-docker cp lambda:/tmp/package.zip package.zip
-docker stop lambda
-docker rm lambda
+$ cd titiler/lambda
+
+$ docker build --tag lambda:latest .
+$ docker run --name lambda -itd lambda:latest /bin/bash
+$ docker cp lambda:/tmp/package.zip package.zip
+$ docker stop lambda
+$ docker rm lambda
 ```
 
-3. Deploy
+2.2. Install serverless and update `serverless.yml`
 
-3.1. Using Serverless
-
-`npm install -g serverless`
+```bash
+$ npm install -g serverless
+```
 
 ```yml
 # serverless.yml
@@ -70,8 +74,39 @@ functions:
           cors: true
 ```
 
-`sls deploy --bucket <my-bucket>`
+2.3. Deploy 
 
-3.2. Using CDK
-    
-**TODO**
+```bash
+$ sls deploy --bucket <my-bucket>
+```
+
+3. Deploy -- Using CDK
+
+3.1. Install cdk and set up CDK in your AWS account - Only need once per account
+
+```bash
+$ npm install cdk -g
+
+$ cdk bootstrap # Deploys the CDK toolkit stack into an AWS environment
+```
+
+3.2. Install dependencies
+
+```bash
+# Note: it's recommanded to use virtualenv
+$ cd titiler && pip install -e .[deploy]
+```
+
+3.3. Pre-Generate CFN template
+
+```bash
+$ cdk synth <projectname-stage>  # Synthesizes and prints the CloudFormation template for this stack
+```
+
+3.4. Deploy
+
+```bash
+$ cdk deploy <projectname-stage>
+```
+
+Note: The CDK commands build the necessary docker image in the background. This may take several minutes depending on internet connection, etc.

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -109,4 +109,5 @@ $ cdk synth <projectname-stage>  # Synthesizes and prints the CloudFormation tem
 $ cdk deploy <projectname-stage>
 ```
 
-Note: The CDK commands build the necessary docker image in the background. This may take several minutes depending on internet connection, etc.
+**Note:** The CDK commands build the necessary docker image in the background. This may take several minutes depending on internet connection, etc.
+**Note:** Due to [compatibility issues](https://github.com/aws/aws-cdk/issues/5877) between some of the aws_cdk libraries and Node v13.X, it's recommended to use Node v12.X

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -110,4 +110,5 @@ $ cdk deploy <projectname-stage>
 ```
 
 **Note:** The CDK commands build the necessary docker image in the background. This may take several minutes depending on internet connection, etc.
+
 **Note:** Due to [compatibility issues](https://github.com/aws/aws-cdk/issues/5877) between some of the aws_cdk libraries and Node v13.X, it's recommended to use Node v12.X

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -5,6 +5,6 @@ from titiler.main import app
 
 handler = Mangum(
     app, 
-    api_gateway_base_path="prod/",
+    api_gateway_base_path="prod",
     enable_lifespan=False
 )

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -5,6 +5,6 @@ from titiler.main import app
 
 handler = Mangum(
     app, 
-    api_gateway_base_path="prod",
+    api_gateway_base_path="prod/api",
     enable_lifespan=False
 )

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -5,6 +5,6 @@ from titiler.main import app
 
 handler = Mangum(
     app, 
-    api_gateway_base_path="prod/api",
+    api_gateway_base_path="prod",
     enable_lifespan=False
 )

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -3,4 +3,8 @@
 from mangum import Mangum
 from titiler.main import app
 
-handler = Mangum(app, enable_lifespan=False)
+handler = Mangum(
+    app, 
+    api_gateway_base_path="prod/",
+    enable_lifespan=False
+)

--- a/lambda/setup_docker.py
+++ b/lambda/setup_docker.py
@@ -1,0 +1,25 @@
+import docker
+import os
+
+
+def make_pkg():
+    file_dir = os.path.dirname(os.path.abspath(__file__))
+    client = docker.from_env()
+    
+    client.images.build(
+        path=os.path.join(file_dir, "..", "lambda"),
+        dockerfile="Dockerfile",
+        tag="lambda:latest"
+    )
+    
+    lambda_container = client.containers.run(
+        name="lambda",
+        image="lambda:latest",
+        command='/bin/sh -c "cp /tmp/package.zip /mnt/output/package.zip"',
+        volumes={
+            "lambda": {"bind": "/mnt/output", "mode": "rw"},
+        }
+    )
+
+
+make_pkg()

--- a/lambda/setup_docker.py
+++ b/lambda/setup_docker.py
@@ -18,7 +18,8 @@ def make_pkg():
         command='/bin/sh -c "cp /tmp/package.zip /mnt/output/package.zip"',
         volumes={
             "lambda": {"bind": "/mnt/output", "mode": "rw"},
-        }
+        },
+        auto_remove=True,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ extra_reqs = {
         "aws-cdk.aws_ec2",
         "aws-cdk.aws_autoscaling",
         "aws-cdk.aws_ecs_patterns",
+        "aws-cdk.aws_lambda",
+        "aws-cdk.aws_apigateway",
     ],
     "test": ["mock", "pytest", "pytest-cov", "pytest-asyncio", "requests"],
 }

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ inst_reqs = [
     "email-validator",
 ]
 extra_reqs = {
-    "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit"],
+    "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit", "docker"],
     "server": ["uvicorn", "click==7.0"],
     "deploy": [
         "aws-cdk.core",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ extra_reqs = {
         "aws-cdk.aws_autoscaling",
         "aws-cdk.aws_ecs_patterns",
         "aws-cdk.aws_lambda",
-        "aws-cdk.aws_apigateway",
+        "aws-cdk.aws_apigatewayv2",
+        "aws-cdk.aws_iam"
     ],
     "test": ["mock", "pytest", "pytest-cov", "pytest-asyncio", "requests"],
 }

--- a/stack/app.py
+++ b/stack/app.py
@@ -27,9 +27,6 @@ class titilerLambdaStack(core.Stack):
         """Define stack."""
         super().__init__(scope, id, *kwargs)
 
-        # create the lambda deployment package
-        # create_lambda_package()
-
         lambda_function = _lambda.Function(
             self,
             f"{id}-lambda",
@@ -84,7 +81,7 @@ class titilerECSStack(core.Stack):
             desired_count=mincount,
             public_load_balancer=True,
             listener_port=80,
-            task_image_options=dict(
+            task_image_options=ecs_patterns.ApplicationLoadBalancedTaskImageOptions(
                 image=ecs.ContainerImage.from_asset(
                     code_dir, exclude=["cdk.out", ".git"]
                 ),

--- a/stack/app.py
+++ b/stack/app.py
@@ -10,7 +10,9 @@ from aws_cdk import (
     aws_ecs as ecs,
     aws_ecs_patterns as ecs_patterns,
     aws_lambda as _lambda,
-    aws_apigateway as apigw,
+    aws_apigateway as apigw, 
+    aws_apigatewayv2 as apigwv2,
+    aws_iam as iam
 )
 
 import config
@@ -36,6 +38,20 @@ class titilerLambdaStack(core.Stack):
         )
 
         apigw.LambdaRestApi(self, f"{id}-endpoint", handler=lambda_function)
+
+        v2_endpoint = apigwv2.CfnApi(
+            self,
+            f"{id}_endpoint_v2",
+            name='titiler http v2 endpoint',
+            protocol_type='HTTP',
+            target = lambda_function.function_arn,
+        )
+        lambda_function.add_permission(
+            f"{id}_gateway_permission",
+            principal=iam.ServicePrincipal('apigateway.amazonaws.com'),
+            action='lambda:InvokeFunction'
+        )
+
 
     def create_package(self, code_dir: str) -> _lambda.Code:
         """test."""


### PR DESCRIPTION
As detailed in lambda/README, Titiler can now be deployed for Lambda using the following commands:
```bash
$ cdk synth <projectname-stackname>
$ cdk deploy <projectname-stackname>
```
**Notes:**
The first time these commands are run, it may take several minutes for the program to execute due to the docker image build (depends on internet connection,etc).

**Issues:**

- The CDK libraries have compatibility issues with Nodejs v13 (see lambda/README)

- Mangum has a known bug extracting the correct route when it comes to API Gateway proxy integration