### PR TITLE
CDK Configuration to simultaneously route requests to Lambda and ECS using Application Load Balancer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ ENV/
 .mypy_cache/
 
 cdk.out/
+
+# lambda deployment package
+lambda/package.zip

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -5,6 +5,6 @@ from titiler.main import app
 
 handler = Mangum(
     app, 
-    api_gateway_base_path="prod/",
+    api_gateway_base_path="prod",
     enable_lifespan=False
 )

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -5,6 +5,6 @@ from titiler.main import app
 
 handler = Mangum(
     app, 
-    api_gateway_base_path="prod",
+    api_gateway_base_path="prod/api",
     enable_lifespan=False
 )

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -5,6 +5,6 @@ from titiler.main import app
 
 handler = Mangum(
     app, 
-    api_gateway_base_path="prod/api",
+    api_gateway_base_path="prod",
     enable_lifespan=False
 )

--- a/lambda/handler.py
+++ b/lambda/handler.py
@@ -3,4 +3,8 @@
 from mangum import Mangum
 from titiler.main import app
 
-handler = Mangum(app, enable_lifespan=False)
+handler = Mangum(
+    app, 
+    api_gateway_base_path="prod/",
+    enable_lifespan=False
+)

--- a/lambda/setup_docker.py
+++ b/lambda/setup_docker.py
@@ -1,0 +1,25 @@
+import docker
+import os
+
+
+def make_pkg():
+    file_dir = os.path.dirname(os.path.abspath(__file__))
+    client = docker.from_env()
+    
+    client.images.build(
+        path=os.path.join(file_dir, "..", "lambda"),
+        dockerfile="Dockerfile",
+        tag="lambda:latest"
+    )
+    
+    lambda_container = client.containers.run(
+        name="lambda",
+        image="lambda:latest",
+        command='/bin/sh -c "cp /tmp/package.zip /mnt/output/package.zip"',
+        volumes={
+            "lambda": {"bind": "/mnt/output", "mode": "rw"},
+        }
+    )
+
+
+make_pkg()

--- a/lambda/setup_docker.py
+++ b/lambda/setup_docker.py
@@ -18,7 +18,8 @@ def make_pkg():
         command='/bin/sh -c "cp /tmp/package.zip /mnt/output/package.zip"',
         volumes={
             "lambda": {"bind": "/mnt/output", "mode": "rw"},
-        }
+        },
+        auto_remove=True,
     )
 
 

--- a/lambda/setup_docker.py
+++ b/lambda/setup_docker.py
@@ -1,25 +1,25 @@
+# coding=utf-8
+
+"""
+Testing docker setup using docker-py
+"""
+
 import docker
 import os
 
 
 def make_pkg():
-    file_dir = os.path.dirname(os.path.abspath(__file__))
+    """ Testing docker setup using docker-py"""
+    # file_dir = os.path.dirname(os.path.abspath(__file__))
     client = docker.from_env()
-    
-    client.images.build(
-        path=os.path.join(file_dir, "..", "lambda"),
-        dockerfile="Dockerfile",
-        tag="lambda:latest"
-    )
-    
-    lambda_container = client.containers.run(
-        name="lambda",
+    code_dir = "./lambda"
+    client.images.build(path=code_dir, dockerfile="Dockerfile", tag="lambda:latest")
+    client.containers.run(
         image="lambda:latest",
-        command='/bin/sh -c "cp /tmp/package.zip /mnt/output/package.zip"',
-        volumes={
-            "lambda": {"bind": "/mnt/output", "mode": "rw"},
-        },
-        auto_remove=True,
+        command="/bin/sh -c 'cp /tmp/package.zip /local/package.zip'",
+        remove=True,
+        volumes={os.path.abspath(code_dir): {"bind": "/local/", "mode": "rw"}},
+        user=0,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ extra_reqs = {
         "aws-cdk.aws_ec2",
         "aws-cdk.aws_autoscaling",
         "aws-cdk.aws_ecs_patterns",
+        "aws-cdk.aws_lambda",
+        "aws-cdk.aws_apigateway",
     ],
     "test": ["mock", "pytest", "pytest-cov", "pytest-asyncio", "requests"],
 }

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ inst_reqs = [
     "email-validator",
 ]
 extra_reqs = {
-    "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit"],
+    "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit", "docker"],
     "server": ["uvicorn", "click==7.0"],
     "deploy": [
         "aws-cdk.core",

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ extra_reqs = {
         "aws-cdk.aws_ecs_patterns",
         "aws-cdk.aws_lambda",
         "aws-cdk.aws_apigateway",
+        "aws-cdk.aws_elasticloadbalancingv2",
     ],
     "test": ["mock", "pytest", "pytest-cov", "pytest-asyncio", "requests"],
 }

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ extra_reqs = {
         "aws-cdk.aws_lambda",
         "aws-cdk.aws_apigateway",
         "aws-cdk.aws_elasticloadbalancingv2",
+        "aws-cdk.aws_elasticloadbalancingv2_targets",
     ],
     "test": ["mock", "pytest", "pytest-cov", "pytest-asyncio", "requests"],
 }

--- a/stack/app.py
+++ b/stack/app.py
@@ -201,27 +201,27 @@ class titilerECSStack(core.Stack):
             desired_count=mincount,
             public_load_balancer=True,
             listener_port=80,
-            # task_image_options=dict(
-            #     image=ecs.ContainerImage.from_asset(
-            #         code_dir, exclude=["cdk.out", ".git"]
-            #     ),
-            #     container_port=80,
-            #     environment=dict(
-            #         CPL_TMPDIR="/tmp",
-            #         GDAL_CACHEMAX="75%",
-            #         GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR",
-            #         GDAL_HTTP_MERGE_CONSECUTIVE_RANGES="YES",
-            #         GDAL_HTTP_MULTIPLEX="YES",
-            #         GDAL_HTTP_VERSION="2",
-            #         MODULE_NAME="titiler.main",
-            #         PYTHONWARNINGS="ignore",
-            #         VARIABLE_NAME="app",
-            #         VSI_CACHE="TRUE",
-            #         VSI_CACHE_SIZE="1000000",
-            #         WORKERS_PER_CORE="1",
-            #         LOG_LEVEL="error",
-            #     ),
-            # ),
+            task_image_options=ecs_patterns.ApplicationLoadBalancedTaskImageOptions(
+                image=ecs.ContainerImage.from_asset(
+                    code_dir, exclude=["cdk.out", ".git"]
+                ),
+                container_port=80,
+                environment=dict(
+                    CPL_TMPDIR="/tmp",
+                    GDAL_CACHEMAX="75%",
+                    GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR",
+                    GDAL_HTTP_MERGE_CONSECUTIVE_RANGES="YES",
+                    GDAL_HTTP_MULTIPLEX="YES",
+                    GDAL_HTTP_VERSION="2",
+                    MODULE_NAME="titiler.main",
+                    PYTHONWARNINGS="ignore",
+                    VARIABLE_NAME="app",
+                    VSI_CACHE="TRUE",
+                    VSI_CACHE_SIZE="1000000",
+                    WORKERS_PER_CORE="1",
+                    LOG_LEVEL="error",
+                ),
+            ),
         )
 
         scalable_target = fargate_service.service.auto_scale_task_count(

--- a/stack/app.py
+++ b/stack/app.py
@@ -23,7 +23,7 @@ class titilerLambdaStack(core.Stack):
     """Titiler Lambda Stack"""
 
     def __init__(
-        self, scope: core.Construct, id: str, code_dir: str = "./", **kwargs: Any,
+        self, scope: core.Construct, id: str, code_dir: str = "./lambda", **kwargs: Any,
     ) -> None:
         """Define stack."""
         super().__init__(scope, id, *kwargs)
@@ -49,9 +49,7 @@ class titilerLambdaStack(core.Stack):
             volumes={os.path.abspath(code_dir): {"bind": "/local/", "mode": "rw"}},
             user=0,
         )
-        return _lambda.Code.asset(
-            os.path.join(code_dir, "package.zip"), exclude=["cdk.out", ".git"]
-        )
+        return _lambda.Code.asset(os.path.join(code_dir, "package.zip"))
 
 
 class titilerStack(core.Stack):
@@ -147,15 +145,6 @@ class titilerStack(core.Stack):
             f"{id}-listener-ecs-target",
             port=80,
             protocol=elbv2.ApplicationProtocol.HTTP,
-            # health_check = dict(
-            #     port= 'traffic-port',
-            #     path= '/',
-            #     intervalSecs= 30,
-            #     timeoutSeconds= 5,
-            #     healthyThresholdCount= 5,
-            #     unhealthyThresholdCount= 2,
-            #     healthyHttpCodes= "200,301,302"
-            # ),
             targets=[fargate_service],
             deregistration_delay=core.Duration.seconds(3),
         )
@@ -179,9 +168,7 @@ class titilerStack(core.Stack):
             volumes={os.path.abspath(code_dir): {"bind": "/local/", "mode": "rw"}},
             user=0,
         )
-        return _lambda.Code.asset(
-            os.path.join(code_dir, "package.zip"), exclude=["cdk.out", ".git"]
-        )
+        return _lambda.Code.asset(os.path.join(code_dir, "package.zip"))
 
 
 class titilerECSStack(core.Stack):

--- a/stack/app.py
+++ b/stack/app.py
@@ -11,43 +11,176 @@ from aws_cdk import (
     aws_ecs_patterns as ecs_patterns,
     aws_lambda as _lambda,
     aws_apigateway as apigw,
+    aws_elasticloadbalancingv2 as elbv2,
 )
 
 import config
 
 import docker
 
-import pathlib
 
 class titilerLambdaStack(core.Stack):
     """Titiler Lambda Stack"""
-    
+
     def __init__(
-        self, 
-        scope: core.Construct,
-        id: str, 
-        code_dir: str = "./", 
-        **kwargs: Any,
+        self, scope: core.Construct, id: str, code_dir: str = "./", **kwargs: Any,
     ) -> None:
         """Define stack."""
-        super().__init__(scope, id, *kwargs)        
-        
-        # create the lambda deployment package
-        create_lambda_package()
+        super().__init__(scope, id, *kwargs)
 
         lambda_function = _lambda.Function(
-            self, f"{id}-lambda",
+            self,
+            f"{id}-lambda",
             runtime=_lambda.Runtime.PYTHON_3_7,
-            code=_lambda.Code.from_asset(
-                os.path.join(code_dir, "lambda", "package.zip"),
-                exclude=["cdk.out", ".git"]
-            ),
-            handler="handler.handler"
+            code=self.create_package(code_dir),
+            handler="handler.handler",
         )
 
-        api_endpoint = apigw.LambdaRestApi(
-            self, f"{id}-endpoint",
-            handler=lambda_function
+        apigw.LambdaRestApi(self, f"{id}-endpoint", handler=lambda_function)
+
+    def create_package(self, code_dir: str) -> _lambda.Code:
+        """Create the lambda deployment package."""
+        client = docker.from_env()
+        client.images.build(path=code_dir, dockerfile="Dockerfile", tag="lambda:latest")
+        client.containers.run(
+            image="lambda:latest",
+            command="/bin/sh -c 'cp /tmp/package.zip /local/package.zip'",
+            remove=True,
+            volumes={os.path.abspath(code_dir): {"bind": "/local/", "mode": "rw"}},
+            user=0,
+        )
+        return _lambda.Code.asset(
+            os.path.join(code_dir, "package.zip"), exclude=["cdk.out", ".git"]
+        )
+
+
+class titilerStack(core.Stack):
+    """Titiler ECS Fargate + Lambda Stack (invoked through application load balancer)"""
+
+    def __init__(
+        self,
+        scope: core.Construct,
+        id: str,
+        cpu: Union[int, float] = 256,
+        memory: Union[int, float] = 512,
+        mincount: int = 1,
+        maxcount: int = 50,
+        code_dir: str = "./",
+        lambda_code_dir: str = "./lambda",
+        **kwargs: Any,
+    ) -> None:
+
+        """Define stack."""
+        super().__init__(scope, id, *kwargs)
+
+        lambda_function = _lambda.Function(
+            self,
+            f"{id}-lambda",
+            runtime=_lambda.Runtime.PYTHON_3_7,
+            code=self.create_package(lambda_code_dir),
+            handler="handler.handler",
+        )
+
+        vpc = ec2.Vpc(self, f"{id}-vpc", max_azs=2)
+
+        security_group = ec2.SecurityGroup(
+            self, f"{id}-securitygroup", allow_all_outbound=True, vpc=vpc
+        )
+
+        security_group.connections.allow_from_any_ipv4(
+            port_range=ec2.Port(
+                protocol=ec2.Protocol.ALL,
+                string_representation="All port 80",
+                from_port=80,
+            ),
+            # TODO: review this description
+            description="Allows traffic on port 80 from NLB",
+        )
+
+        fargate_cluster = ecs.Cluster(self, f"{id}-fargate-cluster", vpc=vpc,)
+
+        task_definition = ecs.FargateTaskDefinition(
+            self, f"{id}-fargate-task-definition", cpu=cpu, memory_limit_mib=memory
+        )
+
+        container = task_definition.add_container(
+            f"{id}-fargate-main-container",
+            image=ecs.ContainerImage.from_asset(code_dir, exclude=["cdk.out", ".git"]),
+            cpu=cpu,
+            environment=dict(
+                CPL_TMPDIR="/tmp",
+                GDAL_CACHEMAX="75%",
+                GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR",
+                GDAL_HTTP_MERGE_CONSECUTIVE_RANGES="YES",
+                GDAL_HTTP_MULTIPLEX="YES",
+                GDAL_HTTP_VERSION="2",
+                MODULE_NAME="titiler.main",
+                PYTHONWARNINGS="ignore",
+                VARIABLE_NAME="app",
+                VSI_CACHE="TRUE",
+                VSI_CACHE_SIZE="1000000",
+                WORKERS_PER_CORE="1",
+                LOG_LEVEL="error",
+            ),
+        )
+        container.add_port_mappings(ecs.PortMapping(container_port=80))
+        fargate_service = ecs.FargateService(
+            self,
+            f"{id}-fargate-service",
+            cluster=fargate_cluster,
+            desired_count=mincount,
+            task_definition=task_definition,
+            security_group=security_group,
+        )
+
+        alb = elbv2.ApplicationLoadBalancer(
+            self,
+            f"{id}-loadbalancer",
+            vpc=vpc,
+            internet_facing=True,
+            security_group=security_group,
+        )
+
+        listener = alb.add_listener(f"{id}-listener", port=80)
+
+        listener.add_targets(
+            f"{id}-listener-ecs-target",
+            port=80,
+            protocol=elbv2.ApplicationProtocol.HTTP,
+            # health_check = dict(
+            #     port= 'traffic-port',
+            #     path= '/',
+            #     intervalSecs= 30,
+            #     timeoutSeconds= 5,
+            #     healthyThresholdCount= 5,
+            #     unhealthyThresholdCount= 2,
+            #     healthyHttpCodes= "200,301,302"
+            # ),
+            targets=[fargate_service],
+            deregistration_delay=core.Duration.seconds(3),
+        )
+
+        listener.add_targets(
+            f"{id}-listener-lambda-targets",
+            port=80,
+            protocol=elbv2.ApplicationProtocol.HTTP,
+            targets=[lambda_function],
+            deregistration_delay=core.Duration.seconds(3),
+        )
+
+    def create_package(self, code_dir: str) -> _lambda.Code:
+        """Create the lambda deployment package."""
+        client = docker.from_env()
+        client.images.build(path=code_dir, dockerfile="Dockerfile", tag="lambda:latest")
+        client.containers.run(
+            image="lambda:latest",
+            command="/bin/sh -c 'cp /tmp/package.zip /local/package.zip'",
+            remove=True,
+            volumes={os.path.abspath(code_dir): {"bind": "/local/", "mode": "rw"}},
+            user=0,
+        )
+        return _lambda.Code.asset(
+            os.path.join(code_dir, "package.zip"), exclude=["cdk.out", ".git"]
         )
 
 
@@ -81,27 +214,27 @@ class titilerECSStack(core.Stack):
             desired_count=mincount,
             public_load_balancer=True,
             listener_port=80,
-            task_image_options=dict(
-                image=ecs.ContainerImage.from_asset(
-                    code_dir, exclude=["cdk.out", ".git"]
-                ),
-                container_port=80,
-                environment=dict(
-                    CPL_TMPDIR="/tmp",
-                    GDAL_CACHEMAX="75%",
-                    GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR",
-                    GDAL_HTTP_MERGE_CONSECUTIVE_RANGES="YES",
-                    GDAL_HTTP_MULTIPLEX="YES",
-                    GDAL_HTTP_VERSION="2",
-                    MODULE_NAME="titiler.main",
-                    PYTHONWARNINGS="ignore",
-                    VARIABLE_NAME="app",
-                    VSI_CACHE="TRUE",
-                    VSI_CACHE_SIZE="1000000",
-                    WORKERS_PER_CORE="1",
-                    LOG_LEVEL="error",
-                ),
-            ),
+            # task_image_options=dict(
+            #     image=ecs.ContainerImage.from_asset(
+            #         code_dir, exclude=["cdk.out", ".git"]
+            #     ),
+            #     container_port=80,
+            #     environment=dict(
+            #         CPL_TMPDIR="/tmp",
+            #         GDAL_CACHEMAX="75%",
+            #         GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR",
+            #         GDAL_HTTP_MERGE_CONSECUTIVE_RANGES="YES",
+            #         GDAL_HTTP_MULTIPLEX="YES",
+            #         GDAL_HTTP_VERSION="2",
+            #         MODULE_NAME="titiler.main",
+            #         PYTHONWARNINGS="ignore",
+            #         VARIABLE_NAME="app",
+            #         VSI_CACHE="TRUE",
+            #         VSI_CACHE_SIZE="1000000",
+            #         WORKERS_PER_CORE="1",
+            #         LOG_LEVEL="error",
+            #     ),
+            # ),
         )
 
         scalable_target = fargate_service.service.auto_scale_task_count(
@@ -130,37 +263,6 @@ class titilerECSStack(core.Stack):
             description="Allows traffic on port 80 from NLB",
         )
 
-def _create_lambda_package():
-    print ("building image")
-    os.system("docker build --tag lambda:latest ./lambda/")
-    
-    print ("running container")
-    os.system("docker run --name lambda -itd lambda:latest /bin/bash")
-    
-    os.system("docker cp lambda:/tmp/package.zip ./lambda/package.zip")
-    os.system("docker stop lambda")
-    os.system("docker rm lambda")
-
-    
-def create_lambda_package():
-    """Creates the lambda deployment package"""
-    code_path = pathlib.Path(os.path.abspath(__file__))
-    file_dir = str(code_path.parent.parent / 'lambda')
-    client = docker.from_env()
-    client.images.build(
-        path=os.path.join(file_dir, "..", "lambda"),
-        dockerfile="Dockerfile",
-        tag="lambda:latest"
-    )
-    lambda_container = client.containers.run(
-        name="lambda",
-        image="lambda:latest",
-        command='/bin/sh -c "cp /tmp/package.zip /mnt/output/package.zip"',
-        volumes={
-            file_dir: {"bind": "/mnt/output", "mode": "rw"},
-        },
-        auto_remove=True,
-    )
 
 app = core.App()
 
@@ -175,7 +277,6 @@ for key, value in {
         core.Tag.add(app, key, value)
 
 ecs_stackname = f"{config.PROJECT_NAME}-ecs-{config.STAGE}"
-
 titilerECSStack(
     app,
     ecs_stackname,
@@ -187,8 +288,17 @@ titilerECSStack(
 
 lambda_stackname = f"{config.PROJECT_NAME}-lambda-{config.STAGE}"
 titilerLambdaStack(
+    app, lambda_stackname,
+)
+
+titiler_stackname = f"{config.PROJECT_NAME}-combined-{config.STAGE}"
+titilerStack(
     app,
-    lambda_stackname,
+    titiler_stackname,
+    cpu=config.TASK_CPU,
+    memory=config.TASK_MEMORY,
+    mincount=config.MIN_ECS_INSTANCES,
+    maxcount=config.MAX_ECS_INSTANCES,
 )
 
 app.synth()

--- a/stack/app.py
+++ b/stack/app.py
@@ -123,7 +123,7 @@ class titilerStack(core.Stack):
             ),
         )
         container.add_port_mappings(ecs.PortMapping(container_port=80))
-        fargate_service = ecs.FargateService(
+        ecs.FargateService(
             self,
             f"{id}-fargate-service",
             cluster=fargate_cluster,
@@ -132,18 +132,18 @@ class titilerStack(core.Stack):
             security_group=security_group,
         )
 
-        scalable_target = fargate_service.service.auto_scale_task_count(
-            min_capacity=mincount, max_capacity=maxcount
-        )
+        # scalable_target = fargate_service.service.auto_scale_task_count(
+        #     min_capacity=mincount, max_capacity=maxcount
+        # )
 
-        # https://github.com/awslabs/aws-rails-provisioner/blob/263782a4250ca1820082bfb059b163a0f2130d02/lib/aws-rails-provisioner/scaling.rb#L343-L387
-        scalable_target.scale_on_request_count(
-            "RequestScaling",
-            requests_per_target=50,
-            scale_in_cooldown=core.Duration.seconds(240),
-            scale_out_cooldown=core.Duration.seconds(30),
-            target_group=fargate_service.target_group,
-        )
+        # # https://github.com/awslabs/aws-rails-provisioner/blob/263782a4250ca1820082bfb059b163a0f2130d02/lib/aws-rails-provisioner/scaling.rb#L343-L387
+        # scalable_target.scale_on_request_count(
+        #     "RequestScaling",
+        #     requests_per_target=50,
+        #     scale_in_cooldown=core.Duration.seconds(240),
+        #     scale_out_cooldown=core.Duration.seconds(30),
+        #     target_group=fargate_service.target_group,
+        # )
 
         alb = elbv2.ApplicationLoadBalancer(
             self,
@@ -165,7 +165,6 @@ class titilerStack(core.Stack):
 
         listener.add_targets(
             f"{id}-listener-lambda-targets",
-            port=80,
             protocol=elbv2.ApplicationProtocol.HTTP,
             targets=[targets.LambdaTarget(lambda_function)],
             deregistration_delay=core.Duration.seconds(3),


### PR DESCRIPTION
A third stack, called `titiler-combined-dev` has been created in `stack/app.py`. 

This contains some attempts at connecting and Application Load Balancer and Lambda function, using the following architecture: 
ALB has a listener -> listener routes requests to target groups (one for lambda and one for ECS) -> each target group contains targets (lambda and individual EC2 instances, as they are spun up or down)

For now only the ALB -> listener -> lambda route is explored. 

The stack deploys without errors, but I have not been able to verify the correct routing of requests from ALB to lambda. 

Next steps are to: find the correct syntax for registering ECS as target of the ALB. (Documentation for Lambda target can be found [here](url))

More research on connecting the ALB and Lambda can be found in issue #1 